### PR TITLE
Better layout for small screens

### DIFF
--- a/src/terms.handlebars
+++ b/src/terms.handlebars
@@ -2,14 +2,9 @@
 {{#> layout title="Akeneo Terms & Conditions"}}
     <div class="container">
         <div class="row">
-            <div class="col-xs-9">
-                <h1>Akeneo Subscription Agreement</h1>
-            </div>
-            <div class="col-xs-3">
-                <p class="align-title pull-right"><b>As of October 18th, 2021<sup>*</sup></b></p>
-            </div>
             <div class="col-xs-12">
-                <p><small><sup>*</sup>Former versions available upon request at <a href="mailto:legal@akeneo.com" target="_blank" rel="noopener noreferrer">legal@akeneo.com</a></small></p>
+                <h1>Akeneo Subscription Agreement</h1>
+                <p><b>As of October 18th, 2021</b><br/><small>Former versions available upon request at <a href="mailto:legal@akeneo.com" target="_blank" rel="noopener noreferrer">legal@akeneo.com</a></small></p>
             </div>
         </div>
         <div class="row terms">


### PR DESCRIPTION
I changed a bit the date place in order to get a better display when looking at the terms on a phone.

**Before**
Big screen
![Screenshot 2021-10-18 at 17 52 54](https://user-images.githubusercontent.com/25225430/137766051-1e66c935-158e-4078-b93f-85c7aace8e39.png)
Small screen
![Screenshot 2021-10-18 at 17 53 16](https://user-images.githubusercontent.com/25225430/137766097-db390e7d-19a6-4f4e-9d7b-b02c6e731ab2.png)

**After**
Big screen
![Screenshot 2021-10-18 at 17 48 14](https://user-images.githubusercontent.com/25225430/137765907-299cfbd2-75d6-42a8-84b3-0c7c29aa26e5.png)
Small screen
![Screenshot 2021-10-18 at 17 49 35](https://user-images.githubusercontent.com/25225430/137765912-df7c4bbc-24f1-4bf0-9da0-bfd7b7491e37.png)