### PR TITLE
Fix Get trained link

### DIFF
--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -128,12 +128,12 @@
             <div class="hidden-xs col-xs-12 col-sm-8 col-md-7 col-lg-5">
                 <h2 class="media-heading">Need more help?</h2>
                 <p>Whether you're having trouble setting up your PIM or modelizing your product data, The Akademy can give you a hand. Do not hesitate to contact us!</p>
-                <a class="btn btn-primary" href="https://www.akeneo.com/training/?source=akeneo-help">Get trained!</a>
+                <a class="btn btn-primary" href="https://www.akeneo.com/training-certification/?source=akeneo-help">Get trained!</a>
             </div>
             <div class="visible-xs col-xs-12">
                 <h2 class="text-center">Need more help?</h2>
                 <p class="text-center">Either you're having trouble setting up your PIM or modelizing your product data, our Akademy can give you a hand. Do not hesitate to contact us!</p>
-                <a href="https://www.akeneo.com/training/?source=akeneo-help"><button class="btn btn-primary center-block">Get trained!</button></a>
+                <a href="https://www.akeneo.com/training-certification/?source=akeneo-help"><button class="btn btn-primary center-block">Get trained!</button></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Following Christine's message: [link](https://akeneo.slack.com/archives/C032F5FAZ/p1653986435807899)
I fixed the link to avoid a 404 error when redirecting users to our Akeneo website > Training & Certification page